### PR TITLE
Add acceptance test project and better error message when worker id is invalid guid

### DIFF
--- a/coordinator.acceptancetests/GlobalUsings.cs
+++ b/coordinator.acceptancetests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/coordinator.acceptancetests/RegistrationTests.cs
+++ b/coordinator.acceptancetests/RegistrationTests.cs
@@ -1,0 +1,56 @@
+using System.Net.Http.Json;
+using coordinator.Application;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace coordinator.acceptancetests;
+
+public class RegistrationTests
+{
+    [Test]
+    public async Task When_sending_valid_registration_request()
+    {
+        var factory = new WebApplicationFactory<JobPool>();
+        var client = factory.CreateClient();
+        var body = new {
+            workerId = "99fd7bb3-57d1-4d27-bc54-028c20060bef",
+            teamName = "Team Name",
+            createJobEndpoint = "http://example.com/create",
+            errorCheckEndpoint = "http://example.com/error",
+        };
+        var bodyContent =  JsonContent.Create(body);
+        var response = await client.PostAsync("/register", bodyContent);
+        Assert.That(response.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.OK));
+        var result = await response.Content.ReadFromJsonAsync<TestRegistrationResult>();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Result, Does.Not.Contain("You must provide valid URIs"));
+        Assert.That(result.Result, Does.Contain(body.teamName));
+        Assert.That(result.Result, Does.Contain(body.workerId));
+        Assert.That(result.Result, Does.Contain(body.createJobEndpoint));
+        Assert.That(result.Result, Does.Contain(body.errorCheckEndpoint));
+        Assert.That(result.Result, Does.Contain("is ready to accept jobs"));
+    }
+
+    [Test]
+    public async Task When_sending_registration_request_with_invalid_workerId()
+    {
+        var factory = new WebApplicationFactory<JobPool>();
+        var client = factory.CreateClient();
+        var body = new {
+            workerId = "not a valid guid",
+            teamName = "Team Name",
+            createJobEndpoint = "http://example.com/create",
+            errorCheckEndpoint = "http://example.com/error",
+        };
+        var bodyContent =  JsonContent.Create(body);
+        var response = await client.PostAsync("/register", bodyContent);
+        Assert.That(response.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.OK));
+        var result = await response.Content.ReadFromJsonAsync<TestRegistrationResult>();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Result, Is.EqualTo("Invalid registration request. The worker ID may not be a valid GUID."));
+    }
+}
+
+public class TestRegistrationResult
+{
+    public string? Result { get; set; }
+}

--- a/coordinator.acceptancetests/coordinator.acceptancetests.csproj
+++ b/coordinator.acceptancetests/coordinator.acceptancetests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\coordinator\coordinator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/coordinator/Controllers/RegisterController.cs
+++ b/coordinator/Controllers/RegisterController.cs
@@ -16,6 +16,7 @@ public class RegisterController : Controller
     [HttpPost]
     public RegistrationResult Index([FromBody] RegistrationRequest registrationRequest)
     {
+        if (registrationRequest == null) return new RegistrationResult { Result = "Invalid registration request. The worker ID may not be a valid GUID." };
         try
         {
             new Uri(registrationRequest.CreateJobEndpoint);

--- a/distributed-calculator.sln
+++ b/distributed-calculator.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "worker", "worker\worker.csp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "coordinator.tests", "coordinator.tests\coordinator.tests.csproj", "{77460961-50F8-4E7F-8E21-01E76E0D4EE6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "coordinator.acceptancetests", "coordinator.acceptancetests\coordinator.acceptancetests.csproj", "{8B4A7839-9D7A-4B6B-95AE-5C7E0DD523A5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{77460961-50F8-4E7F-8E21-01E76E0D4EE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77460961-50F8-4E7F-8E21-01E76E0D4EE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77460961-50F8-4E7F-8E21-01E76E0D4EE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B4A7839-9D7A-4B6B-95AE-5C7E0DD523A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B4A7839-9D7A-4B6B-95AE-5C7E0DD523A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B4A7839-9D7A-4B6B-95AE-5C7E0DD523A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B4A7839-9D7A-4B6B-95AE-5C7E0DD523A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds an acceptance test project to the solution. This project uses an in-memory web server to do acceptance testing.

It also adds tests for the worker registration endpoint. Specifically, it adds one test for the happy path and one test for when the worker id is not a valid GUID. Previously, if the worker id was not a valid GUID, the error message returned would say that the create and error endpoints were invalid.